### PR TITLE
[Code] Tweak page_string calls to make sure all pages of text are ret…

### DIFF
--- a/src/act.informative.c
+++ b/src/act.informative.c
@@ -2943,7 +2943,7 @@ ACMD(do_help)
 
   snprintf(entry, sizeof(entry), "@W%s@n\r\n%s", this_help->keywords, this_help->entry);
   
-  page_string(ch->desc, entry, 0); 
+  page_string(ch->desc, entry, true);
 
   if (!strcmp(this_help->keywords, "RULES POLICIES"))
     ch->player_specials->rules_read[0] = TRUE;

--- a/src/comm.c
+++ b/src/comm.c
@@ -3653,7 +3653,7 @@ void show_help(struct descriptor_data *t, const char *entry)
       write_to_output(t, "\r\n");
       snprintf(buf, sizeof(buf), "%s\r\n[ PRESS RETURN TO CONTINUE ]",
        help_table[mid].entry);
-      page_string(t, buf, 0);
+      page_string(t, buf, true);
       return;
     } else {
       if (chk > 0) bot = mid + 1;

--- a/src/objsave.c
+++ b/src/objsave.c
@@ -407,7 +407,7 @@ void Crash_listrent(struct char_data *ch, char *name)
     }
   }
 
-  page_string(ch->desc,buf,0);
+  page_string(ch->desc,buf,true);
   fclose(fl);
 }
 


### PR DESCRIPTION
Previously a multi-page help (i.e. help class-paladin) would end after the first page regardless of what was selected.