### PR TITLE
[Code] Move declaration for bool has_aff in 'act_wizard.c' out of the…

### DIFF
--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -2654,6 +2654,8 @@ ACMD(do_wizutil)
     {
         switch (subcmd)
         {
+            bool has_aff = FALSE;
+
         case SCMD_REROLL:
             send_to_char(ch, "Rerolled...\r\n");
             roll_real_abils(vict);
@@ -2723,8 +2725,6 @@ ACMD(do_wizutil)
             act("A sudden fireball conjured from nowhere thaws $n!", FALSE, vict, 0, 0, TO_ROOM);
             break;
         case SCMD_UNAFFECT:
-
-            bool has_aff = FALSE;
             for (taeller = 0; taeller < AF_ARRAY_MAX; taeller++)
             {
                 if (AFF_FLAGS(vict)[taeller])


### PR DESCRIPTION
This was giving me a compilation error with gcc 10.2. Moving the declaration out of the case into general switch scope solved the problem.